### PR TITLE
Fix typos in pairwise compare notebook

### DIFF
--- a/docs/example_pairwise_comparisons.ipynb
+++ b/docs/example_pairwise_comparisons.ipynb
@@ -16,10 +16,10 @@
    "execution_count": 1,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2024-12-02T19:52:44.430148Z",
-     "iopub.status.busy": "2024-12-02T19:52:44.430015Z",
-     "iopub.status.idle": "2024-12-02T19:52:44.647935Z",
-     "shell.execute_reply": "2024-12-02T19:52:44.647555Z"
+     "iopub.execute_input": "2024-12-13T20:58:24.149172Z",
+     "iopub.status.busy": "2024-12-13T20:58:24.148996Z",
+     "iopub.status.idle": "2024-12-13T20:58:24.639576Z",
+     "shell.execute_reply": "2024-12-13T20:58:24.639167Z"
     },
     "jukit_cell_id": "JlHVCFc6jg"
    },
@@ -45,10 +45,10 @@
    "execution_count": 2,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2024-12-02T19:52:44.649701Z",
-     "iopub.status.busy": "2024-12-02T19:52:44.649507Z",
-     "iopub.status.idle": "2024-12-02T19:52:44.652722Z",
-     "shell.execute_reply": "2024-12-02T19:52:44.652420Z"
+     "iopub.execute_input": "2024-12-13T20:58:24.641172Z",
+     "iopub.status.busy": "2024-12-13T20:58:24.640979Z",
+     "iopub.status.idle": "2024-12-13T20:58:24.648286Z",
+     "shell.execute_reply": "2024-12-13T20:58:24.647986Z"
     },
     "jukit_cell_id": "KnQdvFxPkd"
    },
@@ -72,10 +72,10 @@
    "execution_count": 3,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2024-12-02T19:52:44.653983Z",
-     "iopub.status.busy": "2024-12-02T19:52:44.653793Z",
-     "iopub.status.idle": "2024-12-02T19:52:44.706713Z",
-     "shell.execute_reply": "2024-12-02T19:52:44.706323Z"
+     "iopub.execute_input": "2024-12-13T20:58:24.649669Z",
+     "iopub.status.busy": "2024-12-13T20:58:24.649556Z",
+     "iopub.status.idle": "2024-12-13T20:58:24.755600Z",
+     "shell.execute_reply": "2024-12-13T20:58:24.755261Z"
     },
     "jukit_cell_id": "dlU1p2c9cE"
    },
@@ -102,10 +102,10 @@
    "execution_count": 4,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2024-12-02T19:52:44.708297Z",
-     "iopub.status.busy": "2024-12-02T19:52:44.708140Z",
-     "iopub.status.idle": "2024-12-02T19:52:44.721039Z",
-     "shell.execute_reply": "2024-12-02T19:52:44.720758Z"
+     "iopub.execute_input": "2024-12-13T20:58:24.756964Z",
+     "iopub.status.busy": "2024-12-13T20:58:24.756808Z",
+     "iopub.status.idle": "2024-12-13T20:58:24.782573Z",
+     "shell.execute_reply": "2024-12-13T20:58:24.782268Z"
     },
     "jukit_cell_id": "gQ5lHlQ04X"
    },
@@ -393,10 +393,10 @@
    "execution_count": 5,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2024-12-02T19:52:44.745963Z",
-     "iopub.status.busy": "2024-12-02T19:52:44.745676Z",
-     "iopub.status.idle": "2024-12-02T19:52:44.748082Z",
-     "shell.execute_reply": "2024-12-02T19:52:44.747780Z"
+     "iopub.execute_input": "2024-12-13T20:58:24.813376Z",
+     "iopub.status.busy": "2024-12-13T20:58:24.813222Z",
+     "iopub.status.idle": "2024-12-13T20:58:24.815733Z",
+     "shell.execute_reply": "2024-12-13T20:58:24.815308Z"
     },
     "jukit_cell_id": "ybX13ZBK8Q"
    },
@@ -435,7 +435,7 @@
     "jukit_cell_id": "6gx14BlSwz"
    },
    "source": [
-    "## Compare between wells and siRNA treatments with the same concentration"
+    "## Compare between different wells and siRNA concentrations"
    ]
   },
   {
@@ -443,10 +443,10 @@
    "execution_count": 6,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2024-12-02T19:52:44.749262Z",
-     "iopub.status.busy": "2024-12-02T19:52:44.749084Z",
-     "iopub.status.idle": "2024-12-02T19:53:08.806010Z",
-     "shell.execute_reply": "2024-12-02T19:53:08.805601Z"
+     "iopub.execute_input": "2024-12-13T20:58:24.817376Z",
+     "iopub.status.busy": "2024-12-13T20:58:24.817198Z",
+     "iopub.status.idle": "2024-12-13T20:58:48.225778Z",
+     "shell.execute_reply": "2024-12-13T20:58:48.225233Z"
     },
     "jukit_cell_id": "CRa8vLBRj8"
    },
@@ -469,10 +469,10 @@
    "execution_count": 7,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2024-12-02T19:53:08.807845Z",
-     "iopub.status.busy": "2024-12-02T19:53:08.807680Z",
-     "iopub.status.idle": "2024-12-02T19:53:08.812868Z",
-     "shell.execute_reply": "2024-12-02T19:53:08.812532Z"
+     "iopub.execute_input": "2024-12-13T20:58:48.227715Z",
+     "iopub.status.busy": "2024-12-13T20:58:48.227573Z",
+     "iopub.status.idle": "2024-12-13T20:58:48.233127Z",
+     "shell.execute_reply": "2024-12-13T20:58:48.232737Z"
     },
     "jukit_cell_id": "cGLOXfXNrN"
    },
@@ -587,10 +587,10 @@
    "execution_count": 8,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2024-12-02T19:53:08.814179Z",
-     "iopub.status.busy": "2024-12-02T19:53:08.814037Z",
-     "iopub.status.idle": "2024-12-02T19:53:08.816150Z",
-     "shell.execute_reply": "2024-12-02T19:53:08.815814Z"
+     "iopub.execute_input": "2024-12-13T20:58:48.234569Z",
+     "iopub.status.busy": "2024-12-13T20:58:48.234289Z",
+     "iopub.status.idle": "2024-12-13T20:58:48.236737Z",
+     "shell.execute_reply": "2024-12-13T20:58:48.236350Z"
     },
     "jukit_cell_id": "qzMvL0c8sb"
    },
@@ -614,10 +614,10 @@
    "execution_count": 9,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2024-12-02T19:53:08.817405Z",
-     "iopub.status.busy": "2024-12-02T19:53:08.817251Z",
-     "iopub.status.idle": "2024-12-02T19:53:08.819387Z",
-     "shell.execute_reply": "2024-12-02T19:53:08.819051Z"
+     "iopub.execute_input": "2024-12-13T20:58:48.238100Z",
+     "iopub.status.busy": "2024-12-13T20:58:48.237864Z",
+     "iopub.status.idle": "2024-12-13T20:58:48.240138Z",
+     "shell.execute_reply": "2024-12-13T20:58:48.239749Z"
     },
     "jukit_cell_id": "7modF1v2ll"
    },
@@ -641,7 +641,7 @@
     "jukit_cell_id": "ucjifXHnJI"
    },
    "source": [
-    "## Compare between different siRNAs and Wells at the same concentrations"
+    "## Compare between different siRNAs and wells at the same concentrations"
    ]
   },
   {
@@ -649,10 +649,10 @@
    "execution_count": 10,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2024-12-02T19:53:08.820624Z",
-     "iopub.status.busy": "2024-12-02T19:53:08.820488Z",
-     "iopub.status.idle": "2024-12-02T19:53:11.115742Z",
-     "shell.execute_reply": "2024-12-02T19:53:11.115336Z"
+     "iopub.execute_input": "2024-12-13T20:58:48.241509Z",
+     "iopub.status.busy": "2024-12-13T20:58:48.241210Z",
+     "iopub.status.idle": "2024-12-13T20:58:50.438288Z",
+     "shell.execute_reply": "2024-12-13T20:58:50.437902Z"
     },
     "jukit_cell_id": "JPLwsPbVsU"
    },
@@ -676,10 +676,10 @@
    "execution_count": 11,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2024-12-02T19:53:11.117480Z",
-     "iopub.status.busy": "2024-12-02T19:53:11.117341Z",
-     "iopub.status.idle": "2024-12-02T19:53:11.122848Z",
-     "shell.execute_reply": "2024-12-02T19:53:11.122493Z"
+     "iopub.execute_input": "2024-12-13T20:58:50.440204Z",
+     "iopub.status.busy": "2024-12-13T20:58:50.440051Z",
+     "iopub.status.idle": "2024-12-13T20:58:50.445450Z",
+     "shell.execute_reply": "2024-12-13T20:58:50.445122Z"
     },
     "jukit_cell_id": "lFR01EXVLC"
    },
@@ -708,62 +708,62 @@
        "      <th>pearsons_correlation</th>\n",
        "      <th>Metadata_Concentration__antehoc_group0</th>\n",
        "      <th>Metadata_Concentration__antehoc_group1</th>\n",
-       "      <th>Metadata_siRNA__posthoc_group0</th>\n",
-       "      <th>Metadata_siRNA__posthoc_group1</th>\n",
        "      <th>Metadata_Well__posthoc_group0</th>\n",
        "      <th>Metadata_Well__posthoc_group1</th>\n",
+       "      <th>Metadata_siRNA__posthoc_group0</th>\n",
+       "      <th>Metadata_siRNA__posthoc_group1</th>\n",
        "    </tr>\n",
        "  </thead>\n",
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>0</th>\n",
-       "      <td>0.128001</td>\n",
-       "      <td>0.001</td>\n",
-       "      <td>0.001</td>\n",
-       "      <td>NF1 Target 1</td>\n",
-       "      <td>NF1 Target 2</td>\n",
-       "      <td>F10</td>\n",
-       "      <td>G10</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>0.190290</td>\n",
-       "      <td>0.001</td>\n",
-       "      <td>0.001</td>\n",
-       "      <td>NF1 Target 1</td>\n",
-       "      <td>NF1 Target 2</td>\n",
-       "      <td>F10</td>\n",
-       "      <td>G4</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2</th>\n",
-       "      <td>0.173737</td>\n",
-       "      <td>0.001</td>\n",
-       "      <td>0.001</td>\n",
-       "      <td>NF1 Target 1</td>\n",
-       "      <td>NF1 Target 2</td>\n",
-       "      <td>F10</td>\n",
-       "      <td>G7</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>3</th>\n",
        "      <td>-0.258292</td>\n",
        "      <td>0.001</td>\n",
        "      <td>0.001</td>\n",
-       "      <td>NF1 Target 1</td>\n",
-       "      <td>Scramble</td>\n",
-       "      <td>F10</td>\n",
        "      <td>E10</td>\n",
+       "      <td>F10</td>\n",
+       "      <td>Scramble</td>\n",
+       "      <td>NF1 Target 1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>-0.011791</td>\n",
+       "      <td>0.001</td>\n",
+       "      <td>0.001</td>\n",
+       "      <td>E10</td>\n",
+       "      <td>F4</td>\n",
+       "      <td>Scramble</td>\n",
+       "      <td>NF1 Target 1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>0.188021</td>\n",
+       "      <td>0.001</td>\n",
+       "      <td>0.001</td>\n",
+       "      <td>E10</td>\n",
+       "      <td>F7</td>\n",
+       "      <td>Scramble</td>\n",
+       "      <td>NF1 Target 1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>-0.045444</td>\n",
+       "      <td>0.001</td>\n",
+       "      <td>0.001</td>\n",
+       "      <td>E10</td>\n",
+       "      <td>G10</td>\n",
+       "      <td>Scramble</td>\n",
+       "      <td>NF1 Target 2</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>4</th>\n",
-       "      <td>0.089742</td>\n",
+       "      <td>-0.081625</td>\n",
        "      <td>0.001</td>\n",
        "      <td>0.001</td>\n",
-       "      <td>NF1 Target 1</td>\n",
+       "      <td>E10</td>\n",
+       "      <td>G4</td>\n",
        "      <td>Scramble</td>\n",
-       "      <td>F10</td>\n",
-       "      <td>E4</td>\n",
+       "      <td>NF1 Target 2</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -771,32 +771,32 @@
       ],
       "text/plain": [
        "   pearsons_correlation  Metadata_Concentration__antehoc_group0  \\\n",
-       "0              0.128001                                   0.001   \n",
-       "1              0.190290                                   0.001   \n",
-       "2              0.173737                                   0.001   \n",
-       "3             -0.258292                                   0.001   \n",
-       "4              0.089742                                   0.001   \n",
+       "0             -0.258292                                   0.001   \n",
+       "1             -0.011791                                   0.001   \n",
+       "2              0.188021                                   0.001   \n",
+       "3             -0.045444                                   0.001   \n",
+       "4             -0.081625                                   0.001   \n",
        "\n",
-       "   Metadata_Concentration__antehoc_group1 Metadata_siRNA__posthoc_group0  \\\n",
-       "0                                   0.001                   NF1 Target 1   \n",
-       "1                                   0.001                   NF1 Target 1   \n",
-       "2                                   0.001                   NF1 Target 1   \n",
-       "3                                   0.001                   NF1 Target 1   \n",
-       "4                                   0.001                   NF1 Target 1   \n",
+       "   Metadata_Concentration__antehoc_group1 Metadata_Well__posthoc_group0  \\\n",
+       "0                                   0.001                           E10   \n",
+       "1                                   0.001                           E10   \n",
+       "2                                   0.001                           E10   \n",
+       "3                                   0.001                           E10   \n",
+       "4                                   0.001                           E10   \n",
        "\n",
-       "  Metadata_siRNA__posthoc_group1 Metadata_Well__posthoc_group0  \\\n",
-       "0                   NF1 Target 2                           F10   \n",
-       "1                   NF1 Target 2                           F10   \n",
-       "2                   NF1 Target 2                           F10   \n",
-       "3                       Scramble                           F10   \n",
-       "4                       Scramble                           F10   \n",
+       "  Metadata_Well__posthoc_group1 Metadata_siRNA__posthoc_group0  \\\n",
+       "0                           F10                       Scramble   \n",
+       "1                            F4                       Scramble   \n",
+       "2                            F7                       Scramble   \n",
+       "3                           G10                       Scramble   \n",
+       "4                            G4                       Scramble   \n",
        "\n",
-       "  Metadata_Well__posthoc_group1  \n",
-       "0                           G10  \n",
-       "1                            G4  \n",
-       "2                            G7  \n",
-       "3                           E10  \n",
-       "4                            E4  "
+       "  Metadata_siRNA__posthoc_group1  \n",
+       "0                   NF1 Target 1  \n",
+       "1                   NF1 Target 1  \n",
+       "2                   NF1 Target 1  \n",
+       "3                   NF1 Target 2  \n",
+       "4                   NF1 Target 2  "
       ]
      },
      "execution_count": 11,
@@ -813,10 +813,10 @@
    "execution_count": 12,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2024-12-02T19:53:11.124166Z",
-     "iopub.status.busy": "2024-12-02T19:53:11.124023Z",
-     "iopub.status.idle": "2024-12-02T19:53:11.126142Z",
-     "shell.execute_reply": "2024-12-02T19:53:11.125797Z"
+     "iopub.execute_input": "2024-12-13T20:58:50.446909Z",
+     "iopub.status.busy": "2024-12-13T20:58:50.446796Z",
+     "iopub.status.idle": "2024-12-13T20:58:50.448816Z",
+     "shell.execute_reply": "2024-12-13T20:58:50.448514Z"
     },
     "jukit_cell_id": "EiRceI8zqd"
    },
@@ -840,10 +840,10 @@
    "execution_count": 13,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2024-12-02T19:53:11.127483Z",
-     "iopub.status.busy": "2024-12-02T19:53:11.127297Z",
-     "iopub.status.idle": "2024-12-02T19:53:11.129395Z",
-     "shell.execute_reply": "2024-12-02T19:53:11.129049Z"
+     "iopub.execute_input": "2024-12-13T20:58:50.450152Z",
+     "iopub.status.busy": "2024-12-13T20:58:50.450027Z",
+     "iopub.status.idle": "2024-12-13T20:58:50.451967Z",
+     "shell.execute_reply": "2024-12-13T20:58:50.451666Z"
     },
     "jukit_cell_id": "uHLGwABthL"
    },
@@ -853,7 +853,7 @@
      "output_type": "stream",
      "text": [
       "Output Dataframe Columns:\n",
-      "['pearsons_correlation', 'Metadata_Concentration__antehoc_group0', 'Metadata_Concentration__antehoc_group1', 'Metadata_siRNA__posthoc_group0', 'Metadata_siRNA__posthoc_group1', 'Metadata_Well__posthoc_group0', 'Metadata_Well__posthoc_group1']\n"
+      "['pearsons_correlation', 'Metadata_Concentration__antehoc_group0', 'Metadata_Concentration__antehoc_group1', 'Metadata_Well__posthoc_group0', 'Metadata_Well__posthoc_group1', 'Metadata_siRNA__posthoc_group0', 'Metadata_siRNA__posthoc_group1']\n"
      ]
     }
    ],
@@ -867,7 +867,7 @@
     "jukit_cell_id": "K9KWpg6A7A"
    },
    "source": [
-    "## Compare between different stains, conditions, and wells\n",
+    "## Compare between different siRNAs and wells at the same concentrations\n",
     "Supplying the _drop_cols parameter excludes wells from the output dataframe, even though wells are used to compare groups."
    ]
   },
@@ -876,10 +876,10 @@
    "execution_count": 14,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2024-12-02T19:53:11.130698Z",
-     "iopub.status.busy": "2024-12-02T19:53:11.130526Z",
-     "iopub.status.idle": "2024-12-02T19:53:13.372280Z",
-     "shell.execute_reply": "2024-12-02T19:53:13.371877Z"
+     "iopub.execute_input": "2024-12-13T20:58:50.453295Z",
+     "iopub.status.busy": "2024-12-13T20:58:50.453169Z",
+     "iopub.status.idle": "2024-12-13T20:58:52.612752Z",
+     "shell.execute_reply": "2024-12-13T20:58:52.612363Z"
     },
     "jukit_cell_id": "OHRc2Dyid6"
    },
@@ -904,10 +904,10 @@
    "execution_count": 15,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2024-12-02T19:53:13.374236Z",
-     "iopub.status.busy": "2024-12-02T19:53:13.374071Z",
-     "iopub.status.idle": "2024-12-02T19:53:13.378578Z",
-     "shell.execute_reply": "2024-12-02T19:53:13.378233Z"
+     "iopub.execute_input": "2024-12-13T20:58:52.614565Z",
+     "iopub.status.busy": "2024-12-13T20:58:52.614438Z",
+     "iopub.status.idle": "2024-12-13T20:58:52.618560Z",
+     "shell.execute_reply": "2024-12-13T20:58:52.618237Z"
     },
     "jukit_cell_id": "rGAPBpItug"
    },
@@ -941,33 +941,33 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>0</th>\n",
-       "      <td>0.128001</td>\n",
+       "      <td>-0.258292</td>\n",
+       "      <td>E10</td>\n",
        "      <td>F10</td>\n",
-       "      <td>G10</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
-       "      <td>0.190290</td>\n",
-       "      <td>F10</td>\n",
-       "      <td>G4</td>\n",
+       "      <td>-0.011791</td>\n",
+       "      <td>E10</td>\n",
+       "      <td>F4</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2</th>\n",
-       "      <td>0.173737</td>\n",
-       "      <td>F10</td>\n",
-       "      <td>G7</td>\n",
+       "      <td>0.188021</td>\n",
+       "      <td>E10</td>\n",
+       "      <td>F7</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>3</th>\n",
-       "      <td>-0.258292</td>\n",
-       "      <td>F10</td>\n",
+       "      <td>-0.045444</td>\n",
        "      <td>E10</td>\n",
+       "      <td>G10</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>4</th>\n",
-       "      <td>0.089742</td>\n",
-       "      <td>F10</td>\n",
-       "      <td>E4</td>\n",
+       "      <td>-0.081625</td>\n",
+       "      <td>E10</td>\n",
+       "      <td>G4</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -975,18 +975,18 @@
       ],
       "text/plain": [
        "   pearsons_correlation Metadata_Well__posthoc_group0  \\\n",
-       "0              0.128001                           F10   \n",
-       "1              0.190290                           F10   \n",
-       "2              0.173737                           F10   \n",
-       "3             -0.258292                           F10   \n",
-       "4              0.089742                           F10   \n",
+       "0             -0.258292                           E10   \n",
+       "1             -0.011791                           E10   \n",
+       "2              0.188021                           E10   \n",
+       "3             -0.045444                           E10   \n",
+       "4             -0.081625                           E10   \n",
        "\n",
        "  Metadata_Well__posthoc_group1  \n",
-       "0                           G10  \n",
-       "1                            G4  \n",
-       "2                            G7  \n",
-       "3                           E10  \n",
-       "4                            E4  "
+       "0                           F10  \n",
+       "1                            F4  \n",
+       "2                            F7  \n",
+       "3                           G10  \n",
+       "4                            G4  "
       ]
      },
      "execution_count": 15,
@@ -1003,10 +1003,10 @@
    "execution_count": 16,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2024-12-02T19:53:13.379837Z",
-     "iopub.status.busy": "2024-12-02T19:53:13.379697Z",
-     "iopub.status.idle": "2024-12-02T19:53:13.381799Z",
-     "shell.execute_reply": "2024-12-02T19:53:13.381472Z"
+     "iopub.execute_input": "2024-12-13T20:58:52.620308Z",
+     "iopub.status.busy": "2024-12-13T20:58:52.620133Z",
+     "iopub.status.idle": "2024-12-13T20:58:52.622432Z",
+     "shell.execute_reply": "2024-12-13T20:58:52.622116Z"
     },
     "jukit_cell_id": "zZHKZyRQcw"
    },
@@ -1030,10 +1030,10 @@
    "execution_count": 17,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2024-12-02T19:53:13.383054Z",
-     "iopub.status.busy": "2024-12-02T19:53:13.382878Z",
-     "iopub.status.idle": "2024-12-02T19:53:13.384941Z",
-     "shell.execute_reply": "2024-12-02T19:53:13.384609Z"
+     "iopub.execute_input": "2024-12-13T20:58:52.624091Z",
+     "iopub.status.busy": "2024-12-13T20:58:52.623907Z",
+     "iopub.status.idle": "2024-12-13T20:58:52.626160Z",
+     "shell.execute_reply": "2024-12-13T20:58:52.625845Z"
     },
     "jukit_cell_id": "8G7ZiPRvd8"
    },


### PR DESCRIPTION
This pr fixes some typos found in the pairwise compare example notebook.