### PR TITLE
Ensure consistent column name prefixes

### DIFF
--- a/src/comparison_tools/PairwiseCompareManager.py
+++ b/src/comparison_tools/PairwiseCompareManager.py
@@ -34,10 +34,10 @@ class PairwiseCompareManager:
         _feat_cols = list(set(_feat_cols))
 
         if _same_columns:
-            _same_columns = list(set(_same_columns))
+            _same_columns = sorted(set(_same_columns))
 
         if _different_columns:
-            _different_columns = list(set(_different_columns))
+            _different_columns = sorted(set(_different_columns))
 
         if _drop_cols:
             _drop_cols = list(set(_drop_cols))


### PR DESCRIPTION
This pr attempts to fix a problem mentioned in #19, where the column name prefixes will change in the resulting dataframe when calling the pairwise compare manager. Thanks for agreeing to see if the same problem occurs again with your notebook @axiomcura. Please let me know if this doesn't fix the issue.